### PR TITLE
fix: add empty history

### DIFF
--- a/src/make_oci
+++ b/src/make_oci
@@ -47,7 +47,8 @@ cat > config << EOF
     "diff_ids": [
       "sha256:$rootfs_sha256"
     ]
-  }
+  },
+  "history": [{}]
 }
 EOF
 


### PR DESCRIPTION
* podman requires an empty history
* possible root cause: https://github.com/containers/buildah/blob/d1a1c53c8e1cb34faa4cc8cb689bb68023c01c5c/image.go#L666
* related: https://github.com/gardenlinux/gardenlinux/commit/00a33ec3bd92f2393a95cc58c64a42f53dc089eb