### PR TITLE
fix: add rosetta support for building amd64 images on apple silicon

### DIFF
--- a/src/chroot
+++ b/src/chroot
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+[ "${1:-}" = --keep-ns ] || exec unshare --map-root-user --mount "$0" --keep-ns "$@"
+shift
+
+mount --rbind --make-rprivate /proc "$1/proc"
+env -i /sbin/chroot "$@"
+umount -l "$1/proc"

--- a/src/unbase_rootfs
+++ b/src/unbase_rootfs
@@ -165,7 +165,7 @@ if [ "$ldd_dependencies" = 1 ]; then
 				fi
 				if [ -n "$interpreter" ]; then
 					# segfaults for go binaries if running under qemu-user-static emulation => always return true
-					{ env -i /sbin/chroot "$target" "$interpreter" --inhibit-cache --list "/$file" 2> /dev/null || true; } | sed 's/^.*=>//;s/^\s*//;s/\s*(\w*)$//' | { grep '^/' || [ $? = 1 ]; } | sed 's|^/||'
+					{ ./chroot "$target" "$interpreter" --inhibit-cache --list "/$file" 2> /dev/null || true; } | sed 's/^.*=>//;s/^\s*//;s/\s*(\w*)$//' | { grep '^/' || [ $? = 1 ]; } | sed 's|^/||'
 				fi
 			fi
 		fi

--- a/unbase_oci
+++ b/unbase_oci
@@ -46,10 +46,15 @@ while [ $# -gt 0 ]; do
 	esac
 done
 
+if [ "$container_image" = localhost/unbase_oci ]; then
+	dir="$(dirname -- "$(realpath -- "${BASH_SOURCE[0]}")")"
+	"$container_engine" build -t "$container_image" "$dir"
+fi
+
 container_mount_opts+=(-v "$(realpath "$1"):/mnt$(realpath "$1")")
 [ "$1" = "$2" ] || container_mount_opts+=(-v "$(realpath "$2"):/mnt$(realpath "$2")")
 [ -e "$3" ] || touch "$3"
 container_mount_opts+=(-v "$(realpath "$3"):/mnt$(realpath "$3")")
 args+=("/mnt$(realpath "$1")" "/mnt$(realpath "$2")" "/mnt$(realpath "$3")")
 
-"$container_engine" run --rm --read-only --tmpfs /tmp:rw,exec "${container_mount_opts[@]}" "$container_image" "${args[@]}"
+"$container_engine" run --rm --security-opt seccomp=unconfined --security-opt apparmor=unconfined --security-opt label=disable --read-only --tmpfs /tmp:rw,exec "${container_mount_opts[@]}" "$container_image" "${args[@]}"


### PR DESCRIPTION
rosetta requires /proc to be mounted in any chroot it operates in, therefore it is necessary to wrap the chroot call inside a mount namespace where /proc gets bind mounted
