### PR TITLE
feat: update SapMachine version to 21.0.8 in Containerfile

### DIFF
--- a/example/sapmachine/Containerfile
+++ b/example/sapmachine/Containerfile
@@ -1,7 +1,7 @@
 FROM debian AS download
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y ca-certificates curl
-RUN curl -sSL https://github.com/SAP/SapMachine/releases/download/sapmachine-20.0.2/sapmachine-jre-20.0.2_linux-$(uname -m | sed 's/x86_64/x64/')_bin.tar.gz | gzip -d | tar -C /opt/ -x
+RUN curl -sSL https://github.com/SAP/SapMachine/releases/download/sapmachine-21.0.8/sapmachine-jre-21.0.8_linux-$(uname -m | sed 's/x86_64/x64/')_bin.tar.gz | gzip -d | tar -C /opt/ -x
 
 FROM debian
-COPY --from=download /opt/sapmachine-jre-20.0.2 /opt/sapmachine-jre-20.0.2
-ENV PATH="$PATH:/opt/sapmachine-jre-20.0.2/bin"
+COPY --from=download /opt/sapmachine-jre-21.0.8 /opt/sapmachine-jre-21.0.8
+ENV PATH="$PATH:/opt/sapmachine-jre-21.0.8/bin"

--- a/example/sapmachine/run_example
+++ b/example/sapmachine/run_example
@@ -32,7 +32,7 @@ podman save --format oci-archive sapmachine > sapmachine.oci
 ../../unbase_oci --container-image "$container_image" --exclude exclude --ldd-dependencies --print-tree debian.oci sapmachine.oci sapmachine_bare.oci
 image="$(podman load < sapmachine_bare.oci | awk '{ print $NF }')"
 podman tag "$image" sapmachine:bare
-podman run --rm sapmachine:bare /opt/sapmachine-jre-20.0.2/bin/java --version
+podman run --rm sapmachine:bare /opt/sapmachine-jre-21.0.8/bin/java --version
 
 if [ ! -e hello.jar ]; then
 	native_arch="$(podman system info --format json | jq -r '.host.arch')"
@@ -41,6 +41,6 @@ if [ ! -e hello.jar ]; then
 	podman run --rm -v "$PWD:/mnt" java bash -c 'cd /mnt && javac HelloWorld.java && jar -c -e HelloWorld -f hello.jar HelloWorld.class'
 fi
 
-podman run --rm -v "$PWD/hello.jar:/hello.jar" sapmachine:bare /opt/sapmachine-jre-20.0.2/bin/java -jar /hello.jar
+podman run --rm -v "$PWD/hello.jar:/hello.jar" sapmachine:bare /opt/sapmachine-jre-21.0.8/bin/java -jar /hello.jar
 
 podman image list --sort size localhost/sapmachine


### PR DESCRIPTION
This should fix this issue that came up because debian Trixie upgraded the default JRE:

java.lang.UnsupportedClassVersionError: HelloWorld has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 64.0
